### PR TITLE
Option to log the filename, this helps when tracing a bad comment that is kicking an error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ function main(options, func) {
         if (file.isStream()) {
             cb(new PluginError("gulp-strip-comments", "Streaming not supported."));
         }
+
+        if (options.logFilename) console.log('decommenting '+ file.path);
+        
         file.contents = new Buffer(func(file.contents.toString(), options));
         this.push(file);
         return cb();


### PR DESCRIPTION
Option to log the filename, this helps when tracing a bad comment that is kicking an error.

This need happened when I had a bad comment with only on slash that caused gulp to exit. I wrote this to help track down which file was the cause
