### PR TITLE
Option to log the filename, this helps when tracing a bad comment that is kicking an error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,30 +16,31 @@ function gulpStripComments(options){
   var line = (typeof opts.line === 'boolean' && opts.line === true);
   var safety = (typeof opts.safe === 'boolean' && opts.safe === false);
 
-var stream = through.obj(function(file, enc, cb){
+  var stream = through.obj(function(file, enc, cb){
 
-  if (file.isNull()) {
-    cb(null, file);
-    return;
-  }
+    if (file.isNull()) {
+      cb(null, file);
+      return;
+    }
 
-  if (file.isStream()) {
-    cb(new PluginError(PLUGIN_NAME, 'Streaming not supported'));
-    return;
-  }
+    if (file.isStream()) {
+      cb(new PluginError(PLUGIN_NAME, 'Streaming not supported'));
+      return;
+    }
 
-  if (noopt || (!block && !line && !first)) {
-    strip = stripComments;
-  } else if (block && line) {
-    this.emit('error', new PluginError(PLUGIN_NAME, 'Please choose either block or line, not both!'));
-  } else if (block) {
-    strip = stripComments.block;
-  } else if (line) {
-    strip = stripComments.line;
-  } else {
-    this.emit('error', new PluginError(PLUGIN_NAME, 'Please define options correctly'));
-  }
+    if (noopt || (!block && !line && !first)) {
+      strip = stripComments;
+    } else if (block && line) {
+      this.emit('error', new PluginError(PLUGIN_NAME, 'Please choose either block or line, not both!'));
+    } else if (block) {
+      strip = stripComments.block;
+    } else if (line) {
+      strip = stripComments.line;
+    } else {
+      this.emit('error', new PluginError(PLUGIN_NAME, 'Please define options correctly'));
+    }
 
+    if (options.logFilename) console.log('decommenting '+ file.path);
     if (file.isBuffer()) {
       file.contents = new Buffer(strip(file.contents.toString(), {safe: safety ? false : true}));
     }


### PR DESCRIPTION
Option to log the filename, this helps when tracing a bad comment that is kicking an error.

This need happened when I had a bad comment with only on slash that caused gulp to exit. I wrote this to help track down which file was the cause

Note: also fixed indenting
